### PR TITLE
Removed Gitter Group

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,5 +3,3 @@
 This site is intended for students of Gateway Community and Technical College who are participating in the NCL competition. We will post links to various tools which will aid you in the competition and/or other hacking competitions Gateway is involved in.
 
 Follow [Gateway's IT department on Facebook](https://www.facebook.com/GCTCIT).
-
-Join our [Unofficial NCL discussion group on Gitter](https://gitter.im/NCL-Cyber-Skyline/Lobby).


### PR DESCRIPTION
Apparently collaboration during the Postseason and Regular season games of the NCL competition is disallowed. Once I became aware of that, I deleted the group on Gitter.
https://docs.wixstatic.com/ugd/766e9a_2dd9ba54a29d477bacb65e4c7ba60b63.docx?dn=2017_NCL_Season_Ethical_Behavior_Rules_Conduct_FINAL-3.docx